### PR TITLE
History

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ elpa-to-submit/nxhtml/etc/schema/xhtml-loader.rnc~
 session*
 tramp
 \#*
+history


### PR DESCRIPTION
Commit message says it all:

Added 'history' to .gitignore.

This is the default value of savehist-file, which shouldn't be kept under version control
