### PR TITLE
Don't set magit-diff-options, which is a string in magit 0.8 and a list in 1.0

### DIFF
--- a/starter-kit-misc.el
+++ b/starter-kit-misc.el
@@ -117,8 +117,7 @@
     (add-to-list 'grep-find-ignored-files "*.class")))
 
 ;; Default to unified diffs
-(setq diff-switches "-u -w"
-      magit-diff-options "-w")
+(setq diff-switches "-u -w")
 
 ;; Cosmetics
 


### PR DESCRIPTION
When I upgraded to magit 1.0, diffs in magit-status started failing with errors like "wrong type argument: stringp, 45" when I hit TAB to show a diff for a change. This turns out to be because magit-diff-options changed from a string to a list. I guess the right thing to do would be to detect the magit version (I'm not sure in which magit version it changed) and set magit-diff-options appropriately. I don't really care if diffs are whitespace-sensitive, so I went the lazy route and just removed this setting completely so that it doesn't matter which version of magit I have.
