### PR TITLE
Load user-specific-dir before user-specific-config

### DIFF
--- a/init.el
+++ b/init.el
@@ -72,8 +72,8 @@
 (add-to-list 'load-path user-specific-dir)
 
 (if (file-exists-p system-specific-config) (load system-specific-config))
-(if (file-exists-p user-specific-config) (load user-specific-config))
 (if (file-exists-p user-specific-dir)
   (mapc #'load (directory-files user-specific-dir nil ".*el$")))
+(if (file-exists-p user-specific-config) (load user-specific-config))
 
 ;;; init.el ends here


### PR DESCRIPTION
I propose `user-specific-config` as the last file to be loaded. This way the user configuration can assume that all the files in `user-specific-dir` have been loaded, therefore reducing the number of configuration lines, the complexity of the configuration file, and the potential for multiple `load`s of the same file.

For example, after this change a user can put his color-theme in the `user-specific-dir` and simply call it in the `user-specific-config`.

Without this change, a user has two possibilities, but none of them is as simple as the previous one:
1. Put the color-theme in the `elpa-to-submit` directory, modifying it according to Emacs's autoload system, and call it;
2. Put the color-theme in the `user-specific-dir`, adding a `load` and a call in the `user-specific-config`.

Note that the last method will invoke two `load`s of the same file: one triggered by the user in the `user-specific-config`, and another one triggered by the emacs-starter-kit in `init.el`
