### PR TITLE
Make unicode fn character transport safe

### DIFF
--- a/modules/starter-kit-lisp.el
+++ b/modules/starter-kit-lisp.el
@@ -86,8 +86,9 @@
     '(font-lock-add-keywords
       'clojure-mode `(("(\\(fn\\>\\)"
                        (0 (progn (compose-region (match-beginning 1)
-                                                 (match-end 1) "ƒ")
+                                                 (match-end 1) "\u0192")
                                  nil)))))))
 
 (provide 'starter-kit-lisp)
 ;;; starter-kit-lisp.el ends here
+


### PR DESCRIPTION
apparently some link in the chain between github and an elpa install
corrupts non-ascii
