### PR TITLE
put pretty function code into a hook function

### DIFF
--- a/starter-kit-defuns.el
+++ b/starter-kit-defuns.el
@@ -218,7 +218,7 @@ Symbols matching the text at point are put first in the completion list."
   (paredit-mode 1))
 
 (defun esk-space-for-delimiter? (endp delimiter)
-  (not (member major-mode '(ruby-mode espresso-mode js2-mode))))
+  (not (member major-mode '(ruby-mode espresso-mode js-mode js2-mode))))
 
 (eval-after-load 'paredit
   '(add-to-list 'paredit-space-for-delimiter-predicates

--- a/starter-kit-js.el
+++ b/starter-kit-js.el
@@ -23,13 +23,8 @@
         '(progn (define-key espresso-mode-map "{" 'paredit-open-curly)
                 (define-key espresso-mode-map "}" 'paredit-close-curly-and-newline)
                 ;; fixes problem with pretty function font-lock
-                (define-key espresso-mode-map (kbd ",") 'self-insert-command)
-                (font-lock-add-keywords
-                 'espresso-mode `(("\\(function *\\)("
-                                   (0 (progn (compose-region (match-beginning 1)
-                                                             (match-end 1) "ƒ")
-                                             nil)))))))
-      )
+                (define-key espresso-mode-map (kbd ",") 'self-insert-command)))
+      (add-hook 'espresso-mode-hook 'pretty-functions))
 
   (autoload 'js-mode "js" "Start js-mode" t)
   (add-to-list 'auto-mode-alist '("\\.js$" . js-mode))
@@ -43,12 +38,15 @@
     '(progn (define-key js-mode-map "{" 'paredit-open-curly)
             (define-key js-mode-map "}" 'paredit-close-curly-and-newline)
             ;; fixes problem with pretty function font-lock
-            (define-key js-mode-map (kbd ",") 'self-insert-command)
-            (font-lock-add-keywords
-             'js-mode `(("\\(function *\\)("
-                               (0 (progn (compose-region (match-beginning 1)
-                                                         (match-end 1) "ƒ")
-                                         nil))))))))
+            (define-key js-mode-map (kbd ",") 'self-insert-command)))
+  (add-hook 'js-mode-hook 'pretty-functions))
+
+(defun pretty-functions ()
+  (font-lock-add-keywords
+   nil `(("\\(function *\\)("
+          (0 (progn (compose-region (match-beginning 1)
+                                    (match-end 1) "ƒ")
+                    nil))))))
 
 (provide 'starter-kit-js)
 ;;; starter-kit-js.el ends here

--- a/starter-kit-js.el
+++ b/starter-kit-js.el
@@ -2,44 +2,28 @@
 ;;
 ;; Part of the Emacs Starter Kit
 
-
 ;; NB: js-mode is part of Emacs since version 23.2 (with an alias
 ;; javascript-mode). It is derived and updated from Espresso mode.
 
-(if (< (string-to-number emacs-version) 23.2)
-    (progn
-      (autoload 'espresso-mode "espresso" "Start espresso-mode" t)
-      (add-to-list 'auto-mode-alist '("\\.js$" . espresso-mode))
-      (add-to-list 'auto-mode-alist '("\\.json$" . espresso-mode))
-      (add-hook 'espresso-mode-hook 'moz-minor-mode)
-      (add-hook 'espresso-mode-hook 'esk-paredit-nonlisp)
-      (add-hook 'espresso-mode-hook 'run-coding-hook)
-      (setq espresso-indent-level 2)
+(defmacro esk-configure-javascript (name)
+  (let ((sym (intern name))
+        (mode (intern (concat name "-mode")))
+        (hook (intern (concat name "-mode-hook")))
+        (keymap (intern (concat name "-mode-map")))
+        (indent (intern (concat name "-indent-level"))))
+    `(progn
+       (autoload ',mode ,name ,(concat "Start " name "-mode") t)
+       (add-to-list 'auto-mode-alist '("\\.js$" . ,mode))
+       (add-to-list 'auto-mode-alist '("\\.json$" . ,mode))
+       (add-hook ',hook 'moz-minor-mode)
+       (add-hook ',hook 'esk-paredit-nonlisp)
+       (add-hook ',hook 'run-coding-hook)
+       (add-hook ',hook 'pretty-functions)       (setq ,indent 2)
 
-      ;; If you prefer js2-mode, use this instead:
-      ;; (add-to-list 'auto-mode-alist '("\\.js$" . espresso-mode))
-
-      (eval-after-load 'espresso
-        '(progn (define-key espresso-mode-map "{" 'paredit-open-curly)
-                (define-key espresso-mode-map "}" 'paredit-close-curly-and-newline)
-                ;; fixes problem with pretty function font-lock
-                (define-key espresso-mode-map (kbd ",") 'self-insert-command)))
-      (add-hook 'espresso-mode-hook 'pretty-functions))
-
-  (autoload 'js-mode "js" "Start js-mode" t)
-  (add-to-list 'auto-mode-alist '("\\.js$" . js-mode))
-  (add-to-list 'auto-mode-alist '("\\.json$" . js-mode))
-  (add-hook 'js-mode-hook 'moz-minor-mode)
-  (add-hook 'js-mode-hook 'esk-paredit-nonlisp)
-  (add-hook 'js-mode-hook 'run-coding-hook)
-  (setq js-indent-level 2)
-
-  (eval-after-load 'js
-    '(progn (define-key js-mode-map "{" 'paredit-open-curly)
-            (define-key js-mode-map "}" 'paredit-close-curly-and-newline)
-            ;; fixes problem with pretty function font-lock
-            (define-key js-mode-map (kbd ",") 'self-insert-command)))
-  (add-hook 'js-mode-hook 'pretty-functions))
+       (eval-after-load ',sym
+         '(progn (define-key ,keymap "{" 'paredit-open-curly)
+                 (define-key ,keymap "}" 'paredit-close-curly-and-newline)
+                 (define-key ,keymap (kbd ",") 'self-insert-command))))))
 
 (defun pretty-functions ()
   (font-lock-add-keywords
@@ -47,6 +31,10 @@
           (0 (progn (compose-region (match-beginning 1)
                                     (match-end 1) "ƒ")
                     nil))))))
+
+(if (< (string-to-number emacs-version) 23.2)
+    (esk-configure-javascript "espresso")
+  (esk-configure-javascript "js"))
 
 (provide 'starter-kit-js)
 ;;; starter-kit-js.el ends here

--- a/starter-kit-js.el
+++ b/starter-kit-js.el
@@ -5,6 +5,10 @@
 ;; NB: js-mode is part of Emacs since version 23.2 (with an alias
 ;; javascript-mode). It is derived and updated from Espresso mode.
 
+(defvar esk-js-mode-hook nil)
+(defun run-esk-js-mode-hook ()
+  (run-hooks 'esk-js-mode-hook))
+
 (defmacro esk-configure-javascript (name)
   (let ((sym (intern name))
         (mode (intern (concat name "-mode")))
@@ -18,7 +22,8 @@
        (add-hook ',hook 'moz-minor-mode)
        (add-hook ',hook 'esk-paredit-nonlisp)
        (add-hook ',hook 'run-coding-hook)
-       (add-hook ',hook 'pretty-functions)       (setq ,indent 2)
+       (add-hook ',hook 'run-esk-js-mode-hook)
+       (setq ,indent 2)
 
        (eval-after-load ',sym
          '(progn (define-key ,keymap "{" 'paredit-open-curly)
@@ -31,6 +36,7 @@
           (0 (progn (compose-region (match-beginning 1)
                                     (match-end 1) "ƒ")
                     nil))))))
+(add-hook 'esk-js-mode-hook 'pretty-functions)
 
 (if (< (string-to-number emacs-version) 23.2)
     (esk-configure-javascript "espresso")


### PR DESCRIPTION
I don't like the unicode replacements, and it feels cleaner to remove a function from a hook than to remove a font-lock keyword.

There is probably a good deal more duplication removal that could be done here, as the setups are essentially identical.
