### PR TITLE
Specify the pretty function character in a more portable way.

### DIFF
--- a/modules/starter-kit-js.el
+++ b/modules/starter-kit-js.el
@@ -54,7 +54,7 @@
           (font-lock-add-keywords
            'js-mode `(("\\(function *\\)("
                        (0 (progn (compose-region (match-beginning 1)
-                                                 (match-end 1) "ƒ")
+                                                 (match-end 1) "\u0192")
                                  nil)))))))
 
 (provide 'starter-kit-js)


### PR DESCRIPTION
I was having some trouble with starter-kit-js module's pretty function. I suspected that this might have something to do with a character encoding problem, since a weird character was being rendered instead of &fnof;.

This pull request apparently solves the problem. I'm using Emacs 24.0.90.1 (x86_64-apple-darwin).

Thanks for pulling together such a great project!
