### PR TITLE
smex-save-file added BEFORE smex-initialize for smex command persistence.

### DIFF
--- a/starter-kit.el
+++ b/starter-kit.el
@@ -53,6 +53,7 @@
 
   (add-to-list 'load-path esk-user-dir)
 
+  (setq smex-save-file (concat user-emacs-directory ".smex-items"))
   (smex-initialize)
   (global-set-key (kbd "M-x") 'smex)
 


### PR DESCRIPTION
smex-save-file added BEFORE smex-initialize for smex command persistence. It will save to emacs-dir/.smex-items
