### PR TITLE
Explicitly enable ido-ubiquitous

### DIFF
--- a/starter-kit-misc.el
+++ b/starter-kit-misc.el
@@ -87,6 +87,18 @@
       ido-handle-duplicate-virtual-buffers 2
       ido-max-prospects 10)
 
+;; Keep spreading that magic ido pixie dust!
+(eval-after-load 'ido-ubiquitous
+  '(cond 
+    ;; New version
+    ((fboundp 'ido-ubiquitous)
+     (ido-ubiquitous 1))
+    ;; Old version
+    ((boundp 'ido-ubiquitous-enabled)
+     ;; Probably not required, since the old version of ido-ubiquitous
+     ;; is enabled by default.
+     (setq ido-ubiquitous-enabled t)))
+
 (set-default 'indent-tabs-mode nil)
 (set-default 'indicate-empty-lines t)
 (set-default 'imenu-auto-rescan t)


### PR DESCRIPTION
The next version of ido-ubiquitous must be explicitly enabled, like any other minor mode. This commit adds some code to do that. See https://github.com/technomancy/ido-ubiquitous/pull/2#issuecomment-2227611
