### PR TITLE
Fix missing closing paren for adding ido-ubiquitous explicit enabling [5c

### DIFF
--- a/starter-kit-misc.el
+++ b/starter-kit-misc.el
@@ -97,7 +97,7 @@
     ((boundp 'ido-ubiquitous-enabled)
      ;; Probably not required, since the old version of ido-ubiquitous
      ;; is enabled by default.
-     (setq ido-ubiquitous-enabled t)))
+     (setq ido-ubiquitous-enabled t))))
 
 (set-default 'indent-tabs-mode nil)
 (set-default 'indicate-empty-lines t)

--- a/starter-kit.el
+++ b/starter-kit.el
@@ -44,6 +44,7 @@
   (dolist (mode '(menu-bar-mode tool-bar-mode scroll-bar-mode))
     (when (fboundp mode) (funcall mode -1)))
 
+  (add-to-list 'load-path (file-name-directory load-file))
   (mapc 'require '(uniquify starter-kit-defuns starter-kit-misc))
 
   ;; You can keep system- or user-specific customizations here

--- a/starter-kit.el
+++ b/starter-kit.el
@@ -44,7 +44,6 @@
   (dolist (mode '(menu-bar-mode tool-bar-mode scroll-bar-mode))
     (when (fboundp mode) (funcall mode -1)))
 
-  (add-to-list 'load-path (file-name-directory load-file))
   (mapc 'require '(uniquify starter-kit-defuns starter-kit-misc))
 
   ;; You can keep system- or user-specific customizations here


### PR DESCRIPTION
Fix missing closing paren for adding ido-ubiquitous explicit enabling [pull request #98] [5c1e197fbbb5c8a1fbc9cbe656ad3c8c81fa06a9]
