### PR TITLE
default to using regexp for query-replace

### DIFF
--- a/modules/starter-kit-bindings.el
+++ b/modules/starter-kit-bindings.el
@@ -64,6 +64,7 @@
   (global-set-key (kbd "\C-r") 'isearch-backward-regexp)
   (global-set-key (kbd "C-M-s") 'isearch-forward)
   (global-set-key (kbd "C-M-r") 'isearch-backward)
+  (global-set-key (kbd "M-%") 'query-replace-regexp)
 
   ;; Jump to a definition in the current file. (Protip: this is awesome.)
   (global-set-key (kbd "C-x C-i") 'imenu)

--- a/modules/starter-kit-bindings.el
+++ b/modules/starter-kit-bindings.el
@@ -62,9 +62,10 @@
   ;; Use regex searches by default.
   (global-set-key (kbd "C-s") 'isearch-forward-regexp)
   (global-set-key (kbd "\C-r") 'isearch-backward-regexp)
+  (global-set-key (kbd "M-%") 'query-replace-regexp)
   (global-set-key (kbd "C-M-s") 'isearch-forward)
   (global-set-key (kbd "C-M-r") 'isearch-backward)
-  (global-set-key (kbd "M-%") 'query-replace-regexp)
+  (global-set-key (kbd "C-M-%") 'query-replace)
 
   ;; Jump to a definition in the current file. (Protip: this is awesome.)
   (global-set-key (kbd "C-x C-i") 'imenu)


### PR DESCRIPTION
I can't come up with a downside to changing the default here.
