### PR TITLE
Load system and user config files after init. Should help with #107.

### DIFF
--- a/starter-kit.el
+++ b/starter-kit.el
@@ -57,10 +57,21 @@
   (smex-initialize)
   (global-set-key (kbd "M-x") 'smex)
 
-  (when (file-exists-p esk-system-config) (load esk-system-config))
-  (when (file-exists-p esk-user-config) (load esk-user-config))
-  (when (file-exists-p esk-user-dir)
-    (mapc 'load (directory-files esk-user-dir nil "^[^#].*el$"))))
+  (defun esk-eval-after-init (form)
+    "Add `(lambda () FORM)' to `after-init-hook'. 
+
+    If Emacs has already finished initialization, also eval FORM immediately."
+    (let ((func (list 'lambda nil form)))
+      (add-hook 'after-init-hook func)
+      (when after-init-time
+        (eval form))))
+
+  (esk-eval-after-init 
+   '(progn 
+      (when (file-exists-p esk-system-config) (load esk-system-config))
+      (when (file-exists-p esk-user-config) (load esk-user-config))
+      (when (file-exists-p esk-user-dir)
+        (mapc 'load (directory-files esk-user-dir nil "^[^#].*el$"))))))
 
 (provide 'starter-kit)
 ;;; starter-kit.el ends here


### PR DESCRIPTION
If my code is correct, this pull request should result in the user and system config files being loaded after init, and hence after all other packages have been loaded.

This should fix #107, assuming that the code works.
