### PR TITLE
Prevent ido-find-file from suggesting "/******" when run on a C comment

### DIFF
--- a/starter-kit-misc.el
+++ b/starter-kit-misc.el
@@ -89,6 +89,22 @@
       ido-handle-duplicate-virtual-buffers 2
       ido-max-prospects 10)
 
+(require 'ffap)
+(defvar ffap-c-commment-regexp "^/\\*+"
+  "Matches an opening C-style comment, like \"/***\".")
+
+(defadvice ffap-guesser (after avoid-c-comments activate)
+  "Don't return paths like \"/******\" unless they actually exist.
+
+This fixes the bug where ido would try to suggest a C-style
+comment as a filename."
+  (ignore-errors
+    (when (and ad-return-value
+               (string-match-p ffap-c-commment-regexp
+                               ad-return-value)
+               (not (ffap-file-exists-string ad-return-value)))
+      (setq ad-return-value nil))))
+
 (set-default 'indent-tabs-mode nil)
 (set-default 'indicate-empty-lines t)
 (set-default 'imenu-auto-rescan t)


### PR DESCRIPTION
Fixes #16.
