### PR TITLE
Ensure tool-bar-mode exists before running it 

### DIFF
--- a/starter-kit-defuns.el
+++ b/starter-kit-defuns.el
@@ -93,7 +93,7 @@
   (run-hooks 'prog-mode-hook))
 
 (defun esk-turn-off-tool-bar ()
-  (tool-bar-mode -1))
+  (if (functionp 'tool-bar-mode) (tool-bar-mode -1)))
 
 (defun esk-untabify-buffer ()
   (interactive)


### PR DESCRIPTION
Hello, that's a small fix that corrects a bug when running emacsclient -nw using emacs-nox.
