### PR TITLE
Fix C-h error on starter-kit-bindings.el install

### DIFF
--- a/modules/starter-kit-bindings.el
+++ b/modules/starter-kit-bindings.el
@@ -91,7 +91,7 @@
   (global-set-key (kbd "C-c x") 'execute-extended-command)
 
   ;; Help should search more than just commands
-  (global-set-key (kbd "C-h a") 'apropos)
+  (define-key 'help-command "a" 'apropos)
 
   ;; Should be able to eval-and-replace anywhere.
   (global-set-key (kbd "C-c e") 'esk-eval-and-replace)


### PR DESCRIPTION
When I do `(package-install "starter-kit-bindings")` I normally get an error,

```
global-set-key: Key sequence C-h a starts with non-prefix key C-h
```

This pull fixes that by defining the key "a" in  `help-command` sparse keycap.

Here is the full trace on that error:

```

Debugger entered--Lisp error: (error "Key sequence C-h a starts with non-prefix key C-h")
  define-key((keymap #^[nil nil keymap 
#^^[3 0 set-mark-command move-beginning-of-line backward-char mode-specific-command-prefix delete-char move-end-of-line forward-char keyboard-quit [backspace] indent-for-tab-command newline-and-indent kill-line recenter-top-bottom newline-and-indent next-line open-line previous-line quoted-insert isearch-backward-regexp isearch-forward-regexp transpose-chars universal-argument scroll-up-command [M-backspace] Control-X-prefix yank t ESC-prefix toggle-input-method abort-recursive-edit nil undo self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command ...] #^^[1 0 #^^[2 0 
#^^[3 0 set-mark-command move-beginning-of-line backward-char mode-specific-command-prefix delete-char move-end-of-line forward-char keyboard-quit [backspace] indent-for-tab-command newline-and-indent kill-line recenter-top-bottom newline-and-indent next-line open-line previous-line quoted-insert isearch-backward-regexp isearch-forward-regexp transpose-chars universal-argument scroll-up-command [M-backspace] Control-X-prefix yank t ESC-prefix toggle-input-method abort-recursive-edit nil undo self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command ...] self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command] self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command] self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command self-insert-command ...] (S-down . windmove-down) (S-up . windmove-up) (S-right . windmove-right) (S-left . windmove-left) (67108907 . text-scale-increase) (C-f10 . menu-bar-mode) (67108910 . repeat) (4194408 . ns-do-hide-emacs) (s-return . ns-toggle-fullscreen) (S-mouse-3 . kmacro-end-call-mouse) (C-wheel-down) (S-wheel-down) (wheel-down . mwheel-scroll) (C-wheel-up) (S-wheel-up) (wheel-up . mwheel-scroll) (ns-show-prefs . customize) (ns-toggle-toolbar . ns-toggle-toolbar) (ns-new-frame . make-frame) (ns-spi-service-call . ns-spi-service-call) (ns-open-file-line . ns-open-file-select-line) (ns-change-font . ns-respond-to-change-font) (ns-drag-text . ns-insert-text) (S-ns-drag-color . ns-set-background-at-mouse) (ns-drag-color . ns-set-foreground-at-mouse) (ns-drag-file . ns-insert-file) (ns-open-temp-file . [ns-open-file]) (ns-open-file . ns-find-file) (ns-power-off . save-buffers-kill-emacs) (S-mouse-1 . mouse-save-then-kill) (kp-next . scroll-up) (kp-prior . scroll-down) (kp-end . end-of-buffer) (kp-home . beginning-of-buffer) (s-left . ns-prev-frame) (s-right . ns-next-frame) (s-kp-bar . shell-command-on-region) (8388732 . shell-command-on-region) (8388730 . undo) (8388729 . ns-paste-secondary) (8388728 . kill-region) (8388727 . delete-frame) (8388726 . yank) (8388725 . revert-buffer) (8388724 . ns-popup-font-panel) (8388723 . save-buffer) (8388721 . save-buffers-kill-emacs) (8388720 . ns-print-buffer) ...) "a" apropos)
  global-set-key("a" apropos)
  eval-buffer(#<buffer  *load*> nil "/Users/dcurtis/.emacs.d/elpa/starter-kit-bindings-2.0.2/starter-kit-bindings-autoloads.el" nil t)  ; Reading at buffer position 1444
  load-with-code-conversion("/Users/dcurtis/.emacs.d/elpa/starter-kit-bindings-2.0.2/starter-kit-bindings-autoloads.el" "/Users/dcurtis/.emacs.d/elpa/starter-kit-bindings-2.0.2/starter-kit-bindings-autoloads.el" nil t)
  load("/Users/dcurtis/.emacs.d/elpa/starter-kit-bindings-2.0.2/starter-kit-bindings-autoloads" nil t)
  package-activate-1(starter-kit-bindings [(2 0 2) ((starter-kit (2 0 2))) "Saner defaults and goodies: bindings"])
  package-activate(starter-kit-bindings (2 0 2))
  package-initialize()
  package-install(starter-kit-bindings)
  call-interactively(package-install record nil)
  command-execute(package-install record)
  smex-read-and-run(("package-install" "package-install-from-buffer" "customize-variable" "widen" "width-80" "eshell" "rename-this-buffer-and-file" "package-list-packages" "grep" "hl-line-mode" "customize-themes" "what-face" "ediff-buffers" "load-file" "revert-buffer" "unfill-paragraph" "markdown-export-latex" "marked" "flyspell-mode" "markdown-mode" "delete-this-buffer-and-file" "whitespace-cleanup" "update-file-autoloads" "qrr" "finder" "replace-string" "yas/minor-mode" "customize-group" "whitespace-mode" "ispell-word" "emacs-init-time" "hl-sentence-mode" "qr" "load-theme" "paredit-mode" "auto-fill-mode" "idle-highlight-mode" "custom-theme-visit-theme" "markdown-cleanup-list-numbers" "compile" "sh-mode" "eval-buffer" "python-mode" "semantic-mode" "view-emacs-FAQ" "package-install-file" "ediff" "c-mode" "text-mode" "abbrev-mode" ...))
  smex()
  call-interactively(smex nil nil)
```
