### PR TITLE
Calling (paredit-mode) etc. from elisp code always enables, not toggles, the mode

### DIFF
--- a/modules/starter-kit-lisp.el
+++ b/modules/starter-kit-lisp.el
@@ -82,7 +82,7 @@
       (font-lock-add-keywords (intern (concat (symbol-name mode) "-mode"))
                               '(("(\\|)" . 'esk-paren-face))))
     (add-hook (intern (concat (symbol-name mode) "-mode-hook"))
-              'esk-turn-on-paredit))
+              'paredit-mode))
 
   (defun esk-pretty-fn ()
     (font-lock-add-keywords nil `(("(\\(\\<fn\\>\\)"

--- a/starter-kit-defuns.el
+++ b/starter-kit-defuns.el
@@ -60,15 +60,6 @@
   (require 'saveplace)
   (setq save-place t))
 
-(defun esk-turn-on-whitespace ()
-  (whitespace-mode t))
-
-(defun esk-turn-on-paredit ()
-  (paredit-mode t))
-
-(defun esk-turn-on-idle-highlight-mode ()
-  (idle-highlight-mode t))
-
 (defun esk-pretty-lambdas ()
   (font-lock-add-keywords
    nil `(("(?\\(lambda\\>\\)"
@@ -87,7 +78,7 @@
 (add-hook 'prog-mode-hook 'esk-turn-on-save-place-mode)
 (add-hook 'prog-mode-hook 'esk-pretty-lambdas)
 (add-hook 'prog-mode-hook 'esk-add-watchwords)
-(add-hook 'prog-mode-hook 'esk-turn-on-idle-highlight-mode)
+(add-hook 'prog-mode-hook 'idle-highlight-mode)
 
 (defun esk-prog-mode-hook ()
   (run-hooks 'prog-mode-hook))


### PR DESCRIPTION
Hi! Something I learned today:

'paredit-mode' with no arguments only toggles the mode when called
interactively. From Lisp, ommitted or 'nil' argument enables the mode -- this
"makes it easy to enable the minor mode in a major mode hook, for example".

See: (info "(elisp) Defining Minor Modes")

I, as no doubt many others, learn a lot of my elisp from your excellent starter
kit; so it would be nice to see this standard way of enabling minor modes
reflected in your code.

Unfortunately this change will break any users' code that calls
esk-turn-on-paredit, esk-turn-on-whitespace, or
esk-turn-on-idle-highlight-mode. For those users the fix is to replace
  (add-hook 'xyz 'esk-turn-on-paredit)
with
  (add-hook 'xyz 'paredit-mode). 
