### PR TITLE
Latest inf-ruby changes on github have changed inf-ruby-keys to inf-ruby-setup-keybindings

### DIFF
--- a/modules/starter-kit-ruby.el
+++ b/modules/starter-kit-ruby.el
@@ -44,7 +44,7 @@
        ;; work around possible elpa bug
        (ignore-errors (require 'ruby-compilation))
        (setq ruby-use-encoding-map nil)
-       (add-hook 'ruby-mode-hook 'inf-ruby-keys)
+       (add-hook 'ruby-mode-hook 'inf-ruby-setup-keybindings)
        (define-key ruby-mode-map (kbd "RET") 'reindent-then-newline-and-indent)
        (define-key ruby-mode-map (kbd "C-M-h") 'backward-kill-word)))
 


### PR DESCRIPTION
Simple rename of a function in inf-ruby.

Commit in question
https://github.com/nonsequitur/inf-ruby/commit/86db14c3155ae72069fb0e4cbd635765c095331d
