### PR TITLE
Require hippie-exp

### DIFF
--- a/starter-kit-misc.el
+++ b/starter-kit-misc.el
@@ -118,11 +118,13 @@ comment as a filename."
 (random t) ;; Seed the random-number generator
 
 ;; Hippie expand: at times perhaps too hip
-(dolist (f '(try-expand-line try-expand-list try-complete-file-name-partially))
-  (delete f hippie-expand-try-functions-list))
-
-;; Add this back in at the end of the list.
-(add-to-list 'hippie-expand-try-functions-list 'try-complete-file-name-partially t)
+(eval-after-load 'hippie-exp
+  '(progn
+     (dolist (f '(try-expand-line try-expand-list try-complete-file-name-partially))
+       (delete f hippie-expand-try-functions-list))
+     
+     ;; Add this back in at the end of the list.
+     (add-to-list 'hippie-expand-try-functions-list 'try-complete-file-name-partially t)))
 
 (eval-after-load 'grep
   '(when (boundp 'grep-find-ignored-files)


### PR DESCRIPTION
On trying to load starter-kit I was getting a void-variable error on hippie-expand-try-functions-list.  I reported this in issue #151. Help in determining the solution was provided by Dmitry Gutov (dgutov).
