### PR TITLE
Remove obsolete inf-ruby-keys hook

### DIFF
--- a/modules/starter-kit-ruby.el
+++ b/modules/starter-kit-ruby.el
@@ -44,7 +44,6 @@
        ;; work around possible elpa bug
        (ignore-errors (require 'ruby-compilation))
        (setq ruby-use-encoding-map nil)
-       (add-hook 'ruby-mode-hook 'inf-ruby-keys)
        (define-key ruby-mode-map (kbd "RET") 'reindent-then-newline-and-indent)
        (define-key ruby-mode-map (kbd "C-M-h") 'backward-kill-word)))
 


### PR DESCRIPTION
inf-ruby-keys was renamed to inf-ruby-setup-keybindings, and is now automatically called. Keeping the hook with the old name leads to an error when loading ruby files.  
