### PR TITLE
ensure font-lock is only applied on correct word

### DIFF
--- a/starter-kit-defuns.el
+++ b/starter-kit-defuns.el
@@ -69,7 +69,7 @@
 
 (defun esk-add-watchwords ()
   (font-lock-add-keywords
-   nil '(("\\<\\(FIX\\(ME\\)?\\|TODO\\|HACK\\|REFACTOR\\|NOCOMMIT\\)"
+   nil '(("\\<\\(FIX\\(ME\\)?\\|TODO\\|HACK\\|REFACTOR\\|NOCOMMIT\\)\\b"
           1 font-lock-warning-face t))))
 
 (add-hook 'prog-mode-hook 'esk-local-column-number-mode)


### PR DESCRIPTION
This fix is to make sure that words like FIXED is not coloured.
