### PR TITLE
fixed deprecated ido-ubiquitous call

### DIFF
--- a/starter-kit-misc.el
+++ b/starter-kit-misc.el
@@ -79,7 +79,7 @@
 
 ;; ido-mode is like magic pixie dust!
 (ido-mode t)
-(ido-ubiquitous t)
+(ido-ubiquitous-mode)
 (setq ido-enable-prefix nil
       ido-enable-flex-matching t
       ido-auto-merge-work-directories-length nil
@@ -110,7 +110,7 @@ comment as a filename."
 (set-default 'imenu-auto-rescan t)
 
 (add-hook 'text-mode-hook 'turn-on-auto-fill)
-;; (when (executable-find ispell-program-name) 
+;; (when (executable-find ispell-program-name)
 ;;       (add-hook 'text-mode-hook 'turn-on-flyspell))
 
 (eval-after-load "ispell"
@@ -129,7 +129,7 @@ comment as a filename."
   '(progn
      (dolist (f '(try-expand-line try-expand-list try-complete-file-name-partially))
        (delete f hippie-expand-try-functions-list))
-     
+
      ;; Add this back in at the end of the list.
      (add-to-list 'hippie-expand-try-functions-list 'try-complete-file-name-partially t)))
 


### PR DESCRIPTION
the function ido-ubiquitous is deprecated, ido-ubiquitous-mode should be called, according to a compilation warning of the starter-kit.

(and I have a mode on that will remove trailing whitespace and I didn't notice that it had changed the file at lines 113 and 132 as well until later)

Kind regards,
Bart S.
