### PR TITLE
Less fragile implementation of esk-eval-and-replace

### DIFF
--- a/starter-kit-defuns.el
+++ b/starter-kit-defuns.el
@@ -115,12 +115,9 @@
 (defun esk-eval-and-replace ()
   "Replace the preceding sexp with its value."
   (interactive)
-  (backward-kill-sexp)
-  (condition-case nil
-      (prin1 (eval (read (current-kill 0)))
-             (current-buffer))
-    (error (message "Invalid expression")
-           (insert (current-kill 0)))))
+  (let ((value (eval (preceding-sexp))))
+    (kill-sexp -1)
+    (insert (format "%s" value))))
 
 (defun esk-sudo-edit (&optional arg)
   (interactive "p")


### PR DESCRIPTION
Instead of killing the sexp first and then reinserting it if evaluation
files, this one doesn't kill the sexp until after _successful_
evaluation, so there's no danger of losing the sexp entirely if it fails
to eval.

Source: http://stackoverflow.com/a/3035574/125921

(I know ESK V2 is not actively developed any more, but I figured you might appreciate the bugfix.)
