### PR TITLE
Update starter-kit-bindings.el

### DIFF
--- a/starter-kit-bindings.el
+++ b/starter-kit-bindings.el
@@ -75,7 +75,7 @@
 
 ;; This is a little hacky since VC doesn't support git add internally
 (eval-after-load 'vc
-  (define-key vc-prefix-map "i" '(lambda () (interactive)
+  '(define-key vc-prefix-map "i" '(lambda () (interactive)
                                    (if (not (eq 'Git (vc-backend buffer-file-name)))
                                        (vc-register)
                                      (shell-command (format "git add %s" buffer-file-name))


### PR DESCRIPTION
The code in the `eval-after-load` form should be quoted (otherwise this won't work as intended).
